### PR TITLE
pluginLogs folder bad location bug fix

### DIFF
--- a/int/utils/filesystem.go
+++ b/int/utils/filesystem.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func GetExecDirPath() (string, error) {
+	execPath, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("failed to get executable path: %v", err)
+	}
+
+	return filepath.Dir(execPath), nil
+}

--- a/main.go
+++ b/main.go
@@ -7,15 +7,20 @@ import (
 
 	"github.com/massalabs/node-manager-plugin/int/api"
 	"github.com/massalabs/node-manager-plugin/int/config"
+	"github.com/massalabs/node-manager-plugin/int/utils"
 	"github.com/massalabs/station/pkg/logger"
 )
 
 const pluginLogPath = "pluginLogs"
 
 func main() {
-	logPath := filepath.Join(pluginLogPath, "node-manager-plugin.log")
+	execDir, err := utils.GetExecDirPath()
+	if err != nil {
+		log.Fatalf("failed to get executable directory path: %v", err)
+	}
+	logPath := filepath.Join(execDir, pluginLogPath, "node-manager-plugin.log")
 
-	err := logger.InitializeGlobal(logPath)
+	err = logger.InitializeGlobal(logPath)
 	if err != nil {
 		log.Fatalf("failed to initialize logger: %v", err)
 	}

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,6 @@
     "description": "Massa blockchain official node manager",
     "logo": "favicon.svg",
     "home": "",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "apispec": ""
   }


### PR DESCRIPTION
pluginsLogs folder used to be located in the folder from which station is launched. Now it is located in the same folder as the node manager executable